### PR TITLE
DEV-3637: Fix CTU shw output

### DIFF
--- a/arch/arm/dts/ipq6018-ctu-100.dts
+++ b/arch/arm/dts/ipq6018-ctu-100.dts
@@ -14,6 +14,7 @@
 /dts-v1/;
 #include "ipq6018-soc.dtsi"
 / {
+	model = "Siklu cTU 100";
 	machid = <0x9010010>;
 	config_name = "config@ctu-100";
 

--- a/common/siklu/siklu_shw.c
+++ b/common/siklu/siklu_shw.c
@@ -52,27 +52,10 @@ static int  get_nand_params (struct mtd_info **mtd_p, unsigned *nand_maf_id,
 // show nand manufacturer info
 static void show_nand_manufacturer_info (struct mtd_info *mtd, int nand_maf_id)
 {
-	/* Try to identify manufacturer */
-	int maf_idx = 0;
 	struct nand_onfi_params *onfi_params = &MTD_NAND_CHIP(mtd)->onfi_params;
 
-	for (maf_idx = 0; nand_manuf_ids[maf_idx].id != 0x0; maf_idx++) {
-		if (nand_manuf_ids[maf_idx].id == nand_maf_id)
-			break;
-	}
-
-	// nand name
-	printf("Name: %s ", nand_manuf_ids[maf_idx].name);
-
-	// nand model
-	if (onfi_params)
-	{
-		printf("%s, ", onfi_params->model);
-	}
-	else
-	{
-		printf("%s, ", mtd->name);
-	}
+	// nand name and model
+	printf("Name: %s %s, ", onfi_params->manufacturer, onfi_params->model);
 
 	// nand Manufacturer ID
 	printf("Manufacturer ID: 0x%02x, ",nand_maf_id);

--- a/common/siklu/siklu_shw.c
+++ b/common/siklu/siklu_shw.c
@@ -1,4 +1,5 @@
 #include <common.h>
+#include <spi_flash.h>
 #include <linux/mtd/nand.h>
 #include <asm/arch-qca-common/qpic_nand.h>
 #include <siklu/siklu_board_generic.h>
@@ -116,20 +117,22 @@ static void show_dram_info (void)
 // show SF (NOR)
 static void show_sf_info (void)
 {
+	struct spi_flash *flash;
+
 	printf("SF: ");
 
-	/* ipq_spi_flash registers the SPI flash as a nand device */
-	struct mtd_info *nor = get_mtd_device_nm("nand1");
-	if (nor == NULL)
+	/* max_hz and spi_mode parameters are ignored */
+	flash = spi_flash_probe(0, 0, 0, 0);
+	if (flash == NULL)
 	{
 		printf("Unknown\n");
 		return;
 	}
 
-	printf("%s with page size ", nor->name);
-	print_size(nor->writesize, ", erase size ");
-	print_size(nor->erasesize, ", total ");
-	print_size(nor->size, "");
+	printf("%s with page size ", flash->name);
+	print_size(flash->page_size, ", erase size ");
+	print_size(flash->erase_size, ", total ");
+	print_size(flash->size, "");
 	printf ("\n");
 }
 

--- a/include/configs/ipq6018.h
+++ b/include/configs/ipq6018.h
@@ -292,6 +292,9 @@ extern loff_t board_env_size;
 #define NUM_ALT_PARTITION		16
 /* The ipq_spi_flash driver registers a nand device for the SPI flash */
 #define MTDIDS_DEFAULT			"nand0=qcom_nand.0,nand1=spi0.0"
+#ifndef MTDPARTS_DEFAULT
+#define MTDPARTS_DEFAULT		"mtdparts=qcom_nand.0:200m(first_bank),200m(second_bank),55m(data),20m(customer),-(log)"
+#endif
 
 #define CONFIG_CMD_UBI
 #define CONFIG_RBTREE


### PR DESCRIPTION
This PR fixes the output of the `shw` command. `shw` now correctly shows SPI and NAND flash identification, as well as machine mode string.

The first commit is added to make stand-alone U-Boot build easier, which is very useful during development.