### PR TITLE
DEV-3691: sled command for PWR led is behaving wrong

### DIFF
--- a/common/siklu/siklu_led_control.c
+++ b/common/siklu/siklu_led_control.c
@@ -91,8 +91,8 @@ static const siklu_dual_led_def_t siklu_led_ipq6010_ctu[] =
 {
 	[SIKLU_LED_POWER] = {
 		.method = LED_METHOD_GPIO,
-		.yellow_gpio = 24,
-		.green_gpio  = 23,
+		.yellow_gpio = 23,
+		.green_gpio  = 24,
 	},
 	[SIKLU_LED_WLAN] = {
 		.method = LED_METHOD_GPIO,


### PR DESCRIPTION
DEV-3691 - gpio numbers of power green and yellow were replaced.
correct is: green=24,  yellow=23
