### PR TITLE
feat(uboot): Add usb_tftp option to siklu_nfs_boot command

### DIFF
--- a/cmd/siklu/siklu_nfs_boot.c
+++ b/cmd/siklu/siklu_nfs_boot.c
@@ -241,6 +241,6 @@ U_BOOT_CMD(
 		2,
 		0,
 		do_nfs_boot,
-		"siklu_nfs_boot [usb]",
+		"siklu_nfs_boot [usb | usb_tftp]",
 		"Loads the system from NFS\n"
 );


### PR DESCRIPTION
DEV-3886: After supporting loading image through tftp add it also to the help command usage.
It will look like that:
siklu_nfs_boot - siklu_nfs_boot [usb | usb_tftp]

