### PR TITLE
siklu: don't use big local variables

### DIFF
--- a/common/siklu/common_boot.c
+++ b/common/siklu/common_boot.c
@@ -8,7 +8,7 @@
 #define BOOT_DIR "/boot"
 
 void setup_bootargs(const char *bootargs) {
-	char formatted_bootargs[1024];
+	static char formatted_bootargs[1024];
 	const char *mtdparts;
 	const char *old_bootargs;
 
@@ -94,9 +94,9 @@ static char *boot_command(void)
 }
 
 int load_kernel_image(void) {
-	char buff[256];
+	static char buff[256];
+	static char formatted_bootargs[1024];
 	int ret;
-	char formatted_bootargs[1024];
 	const char *old_bootargs;
 	char *boot_cmd_format;
 	unsigned long fdt_addr;

--- a/common/siklu/siklu_nand_boot.c
+++ b/common/siklu/siklu_nand_boot.c
@@ -69,7 +69,7 @@ static int load_from_ubifs(void) {
  * @param bank a valid software bank.
  */
 static void set_bootargs_for_bank(struct software_bank_t *bank) {
-	char bootargs[1024];
+	static char bootargs[1024];
 	
 	snprintf(bootargs, sizeof(bootargs),
 			 "ubi.mtd=%s root=ubi0:%s rootfstype=ubifs",

--- a/common/siklu/siklu_nfs_boot.c
+++ b/common/siklu/siklu_nfs_boot.c
@@ -18,7 +18,7 @@
 #define USB_RESET_GPIO_PIN 	55
 
 static int nfs_get_file(const char *path, const char *file, char *address) {
-	char cmd[1024];
+	static char cmd[1024];
 	
 	snprintf(cmd, sizeof(cmd), 
 			"nfs \"%s\" \"%s:%s/%s\"", address, getenv(ENV_NFS_SERVERIP), path, file);
@@ -99,9 +99,9 @@ setup_rootpath(char *output, size_t output_size) {
 
 static void 
 setup_nfs_bootargs(const char *rootpath, bool usb) {
-	char bootargs[1024];
-	char nfsroot[512];
-	char ip[512];
+	static char bootargs[1024];
+	static char nfsroot[512];
+	static char ip[512];
 	const char *netmask;
 	const char *nfs_netdev = CONFIG_SIKLU_NFS_NETDEV;
 	const char *gateway;
@@ -197,9 +197,8 @@ static int
 do_nfs_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 			char *const argv[])
 {
-
+	static char rootpath[1024];
 	int ret;
-	char rootpath[1024];
 	bool usb = false;
 
 	/** Check for USB */

--- a/common/siklu/siklu_nfs_boot.c
+++ b/common/siklu/siklu_nfs_boot.c
@@ -26,7 +26,7 @@ static int nfs_get_file(const char *path, const char *file, char *address) {
 	return run_command(cmd, 0);
 }
 
-int format_rootpath_and_developer_id(const char *rootpath, const char *developer_id, 
+static int format_rootpath_and_developer_id(const char *rootpath, const char *developer_id, 
 		char *output, size_t output_size) {
 	size_t ret;
 	


### PR DESCRIPTION
Previously, we used big (e.g. >=1KiB) buffers on the stack. This is
discouraged and caused strange runtime behavior and crashes.

As a replacement, allocate big buffers statically.