### PR TITLE
IPQ6018 CTU changes

### DIFF
--- a/arch/arm/dts/ipq6018-ctu-100.dts
+++ b/arch/arm/dts/ipq6018-ctu-100.dts
@@ -61,5 +61,16 @@
 			};
 		};
 	};
+
+	gpio {
+		gpio43 {
+			gpio = <43>;
+			func = <0>;
+			out  = <GPIO_OUTPUT>;
+			pull = <GPIO_PULL_UP>;
+			drvstr = <GPIO_8MA>;
+			oe = <GPIO_OE_ENABLE>;
+		};
+	};
 };
 

--- a/arch/arm/dts/ipq6018-ctu-100.dts
+++ b/arch/arm/dts/ipq6018-ctu-100.dts
@@ -28,7 +28,7 @@
 	};
 
 	xhci@8a00000 {
-		perst_gpio = <55>;
+		perst_gpio = <55 43>;
 	};
 
 	xhci@7000000 {

--- a/board/qca/arm/common/board_init.c
+++ b/board/qca/arm/common/board_init.c
@@ -90,12 +90,26 @@ __weak void sdi_disable(void)
 	return;
 }
 
+/**
+ * Add an option to initialize GPIOs without any SPI/NAND/etc. 
+ */
+void siklu_ipq_init_gpio(void) {
+	printf("Initialzing GPIOs!\n");
+
+	int gpio_node;
+
+	gpio_node = fdt_path_offset(gd->fdt_blob, "/gpio");
+	if (gpio_node)
+		qca_gpio_init(gpio_node);
+}
+
 int board_init(void)
 {
 	int ret;
 	uint32_t start_blocks;
 	uint32_t size_blocks;
 
+	siklu_ipq_init_gpio();
 
 	if (!fdt_node_check_compatible(gd->fdt_blob, 0, "siklu,ipq6018-ctu")) {
 		siklu_ctu_ipq6018_power_leds_init();

--- a/include/configs/ipq6018.h
+++ b/include/configs/ipq6018.h
@@ -333,9 +333,6 @@ extern loff_t board_env_size;
 #define CONFIG_CMD_DHCP
 #define CONFIG_MII
 #define CONFIG_CMD_MII
-#define CONFIG_IPADDR		192.168.10.10
-#define CONFIG_NETMASK		255.255.255.0
-#define CONFIG_SERVERIP		192.168.10.1
 #define CONFIG_CMD_TFTPPUT
 #define CONFIG_IPQ_MDIO			1
 #define CONFIG_IPQ_ETH_INIT_DEFER

--- a/include/configs/ipq6018.h
+++ b/include/configs/ipq6018.h
@@ -337,6 +337,9 @@ extern loff_t board_env_size;
 #define CONFIG_IPQ_MDIO			1
 #define CONFIG_IPQ_ETH_INIT_DEFER
 
+/* No one wants dhcp to load the kernel */
+#define CONFIG_SYS_AUTOLOAD "no"
+
 /*
  * CRASH DUMP ENABLE
  */


### PR DESCRIPTION
The purpose of this PR is to update the IPQ6018 u-boot so it will be ready for all HWs. 

This PR includes: 
* Environment adjustments
* Add USB support for PCB263A V1 and PCB263A V2.

### Tests
* Verified on PCB263A V1 and PCB263A V2, that `siklu_nfs_boot usb` works properly and loads the rootfs.