### PR TITLE
DEV-2933: Blink cTU green power LED

### DIFF
--- a/arch/arm/dts/ipq6018-ctu-100.dts
+++ b/arch/arm/dts/ipq6018-ctu-100.dts
@@ -71,6 +71,13 @@
 			drvstr = <GPIO_8MA>;
 			oe = <GPIO_OE_ENABLE>;
 		};
+
+		gpio24 {
+			gpio = <24>;
+			func = <2>;
+			pull = <GPIO_PULL_UP>;
+			oe = <GPIO_OE_ENABLE>;
+		};
 	};
 };
 

--- a/common/siklu/siklu_board_ctu_ipq6018.c
+++ b/common/siklu/siklu_board_ctu_ipq6018.c
@@ -1,13 +1,31 @@
+#include <asm/io.h>
 #include <asm/arch-qca-common/gpio.h>
 #include <siklu/siklu_board_ctu_ipq6018.h>
 
-#define POWER_LED_YELLOW_COLOR_GPIO_PIN 23
+static void set_led_pwm(void)
+{
+    /* Configure PWM dividers */
+    writel(0x7a11f423, 0x1941020);
+    writel(0x9f, 0x1941024);
+    /* Enable PWM */
+    writel(0xc000009f, 0x1941024);
+}
 
+/*
+ * The green color on the power LED is connected to GPIO 24. GPIO 24 is muxed
+ * to the PWM2 function. Configure PWM2 to 10 Hz with 50% duty cycle to make the
+ * LED blink.
+ */
 void siklu_ctu_ipq6018_power_leds_init(void)
 {
-    /*
-    Yellow color of the power led does not turn on automatically after board power on 
-    because of HW bug so we need to do it manually 
-    */
-    gpio_direction_output(POWER_LED_YELLOW_COLOR_GPIO_PIN, 1);
+    /* Set adss_pwm_clk_src source to gpll0 */
+    writel(0x10f, 0x181c00c);
+    /* Enable adss_pwm_clk_src */
+    writel(0x80000001, 0x181c008);
+    /* Enable gcc_adss_pwm_clk */
+    writel(0x80000001, 0x181c020);
+
+    set_led_pwm();
+    /* For some reason we have to repeat that to take affect */
+    set_led_pwm();
 }


### PR DESCRIPTION
Configure the pin connected to the green half of the power LED as PWM to
make it blink on early boot.

JIRA: DEV-2933