### PR TITLE
feature/DEV-4969-add-counter-for-failed-boots

### DIFF
--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -85,7 +85,7 @@ struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_
 
 	config_boot_tries_left = siklu_fdt_getprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, NULL);
 	if (IS_ERR(config_boot_tries_left)) {
-		printf("Could not read boot_tries_left\n");
+		printf("SIKLU_BOOT: Could not read boot_tries_left\n");
 		return bank;
 	}
 
@@ -96,8 +96,12 @@ struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_
 		return bank;
 	} else if (boot_tries_left == 0) {
 		// out of tries, switch bank
-		bank = (bank == &first_bank) ? &second_bank : &first_bank;
-		siklu_fdt_setprop_string(fdt, "/", PROP_CURRENT_BANK, bank->bank_label);
+		if (bank != &first_bank && bank != &second_bank) {
+			printf("SIKLU_BOOT: Could not switch bank, wrong bank specified\n");
+		} else {
+			bank = (bank == &first_bank) ? &second_bank : &first_bank;
+			siklu_fdt_setprop_string(fdt, "/", PROP_CURRENT_BANK, bank->bank_label);
+		}
 	}
 
 	// decrement boot_tries_left for next boot

--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -75,7 +75,7 @@ fail:
 	return bank;
 }
 
-int bank_management_get_boot_tries_left() {
+int8_t bank_management_get_boot_tries_left() {
 	u_char *fdt = NULL;
 	int8_t boot_tries_left = -1; // negative is disabled
 	const char *config_boot_tries_left;
@@ -91,7 +91,6 @@ int bank_management_get_boot_tries_left() {
 	config_boot_tries_left = siklu_fdt_getprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, NULL);
 	if (IS_ERR(config_boot_tries_left)) {
 		printf("SIKLU_BOOT: Could not read boot_tries_left\n");
-
 		goto fail_free;
 	}
 

--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -75,6 +75,7 @@ struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_
 	u_char *fdt = NULL;
 	int8_t boot_tries_left = -1; // negative is disabled
 	const char *config_boot_tries_left;
+	bool do_fdt_write = false;
 
 	fdt = siklu_read_fdt_from_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART);
 	if (! fdt) {
@@ -101,6 +102,7 @@ struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_
 		} else {
 			bank = (bank == &first_bank) ? &second_bank : &first_bank;
 			siklu_fdt_setprop_string(fdt, "/", PROP_CURRENT_BANK, bank->bank_label);
+			do_fdt_write = true;
 		}
 	}
 
@@ -108,9 +110,12 @@ struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_
 	char boot_tries_left_str[5]; // "-123\0"
 	if (0 < snprintf(boot_tries_left_str, sizeof(boot_tries_left_str), "%d", boot_tries_left - 1)) {
 		siklu_fdt_setprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, boot_tries_left_str);
+		do_fdt_write = true;
 	}
 
-	siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
+	if (do_fdt_write) {
+		siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
+	}
 
 	return bank;
 }

--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -92,19 +92,20 @@ struct software_bank_t* bank_management_switch_current_bank(struct software_bank
 	printf("SIKLU BOOT: boot_tries_left = %s\n", config_boot_tries_left);
 	boot_tries_left = simple_strtol(config_boot_tries_left, NULL, 10);
 	if (boot_tries_left < 0) {
+		// do nothing
 		return bank;
-	} else {
-		// decrement boot_tries_left for next boot
-		char boot_tries_left_str[5]; // "-123\0"
-		if (0 < snprintf(boot_tries_left_str, sizeof(boot_tries_left_str), "%d", boot_tries_left - 1)) {
-			siklu_fdt_setprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, boot_tries_left_str);
-		}
-	}
-	if (boot_tries_left == 0) {
+	} else if (boot_tries_left == 0) {
 		// out of tries, switch bank
 		bank = (bank == &first_bank) ? &second_bank : &first_bank;
 		siklu_fdt_setprop_string(fdt, "/", PROP_CURRENT_BANK, bank->bank_label);
 	}
+
+	// decrement boot_tries_left for next boot
+	char boot_tries_left_str[5]; // "-123\0"
+	if (0 < snprintf(boot_tries_left_str, sizeof(boot_tries_left_str), "%d", boot_tries_left - 1)) {
+		siklu_fdt_setprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, boot_tries_left_str);
+	}
+
 	siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
 
 	return bank;

--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -89,7 +89,7 @@ struct software_bank_t* bank_management_switch_current_bank(struct software_bank
 		return bank;
 	}
 
-	printf("boot_tries_left = %s\n", config_boot_tries_left);
+	printf("SIKLU BOOT: boot_tries_left = %s\n", config_boot_tries_left);
 	boot_tries_left = simple_strtol(config_boot_tries_left, NULL, 10);
 	if (boot_tries_left < 0) {
 		return bank;

--- a/cmd/siklu/bank_management.c
+++ b/cmd/siklu/bank_management.c
@@ -71,7 +71,7 @@ fail:
 	return bank;
 }
 
-struct software_bank_t* bank_management_switch_current_bank(struct software_bank_t *bank) {
+struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_t *bank) {
 	u_char *fdt = NULL;
 	int8_t boot_tries_left = -1; // negative is disabled
 	const char *config_boot_tries_left;

--- a/cmd/siklu/bank_management.h
+++ b/cmd/siklu/bank_management.h
@@ -11,12 +11,12 @@ struct software_bank_t {
  */
 struct software_bank_t* bank_management_get_current_bank(void);
 /**
- * Switch current software bank if boot_tries_left == 0.
+ * Switch software bank if boot_tries_left == 0.
  * Decrease boot_tries_left when >= 0.
  * Do nothing when boot_tries_left < 0.
  * @param bank  current software bank.
  * @return a pointer to updated software_bank_t.
  */
-struct software_bank_t* bank_management_switch_current_bank(struct software_bank_t *bank);
+struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_t *bank);
 
 #endif

--- a/cmd/siklu/bank_management.h
+++ b/cmd/siklu/bank_management.h
@@ -1,22 +1,23 @@
 #ifndef __SIKLU_BANK_MANAGEMENT_H__
 #define __SIKLU_BANK_MANAGEMENT_H__
 
+#include <linux/types.h>
+
 struct software_bank_t {
 	const char* bank_label;
 };
 
 /**
- * Get the current software bank.
+ * Get the current software bank, update current bank if failover happened
+ * @param do_failover  do a bank switch and save changes
  * @return a pointer to a valid software_bank_t.
  */
-struct software_bank_t* bank_management_get_current_bank(void);
+struct software_bank_t* bank_management_get_current_bank(bool do_failover);
+
 /**
- * Switch software bank if boot_tries_left == 0.
- * Decrease boot_tries_left when >= 0.
- * Do nothing when boot_tries_left < 0.
- * @param bank  current software bank.
- * @return a pointer to updated software_bank_t.
+ * Get current boot_tries_left, decrease value for next boot
+ * @return count of boot tries left or -1 on fail
  */
-struct software_bank_t* bank_management_handle_auto_switch(struct software_bank_t *bank);
+int bank_management_get_boot_tries_left();
 
 #endif

--- a/cmd/siklu/bank_management.h
+++ b/cmd/siklu/bank_management.h
@@ -10,5 +10,13 @@ struct software_bank_t {
  * @return a pointer to a valid software_bank_t.
  */
 struct software_bank_t* bank_management_get_current_bank(void);
+/**
+ * Switch current software bank if boot_tries_left == 0.
+ * Decrease boot_tries_left when >= 0.
+ * Do nothing when boot_tries_left < 0.
+ * @param bank  current software bank.
+ * @return a pointer to updated software_bank_t.
+ */
+struct software_bank_t* bank_management_switch_current_bank(struct software_bank_t *bank);
 
 #endif

--- a/cmd/siklu/bank_management.h
+++ b/cmd/siklu/bank_management.h
@@ -18,6 +18,6 @@ struct software_bank_t* bank_management_get_current_bank(bool do_failover);
  * Get current boot_tries_left, decrease value for next boot
  * @return count of boot tries left or -1 on fail
  */
-int bank_management_get_boot_tries_left();
+int8_t bank_management_get_boot_tries_left();
 
 #endif

--- a/cmd/siklu/definitions.h
+++ b/cmd/siklu/definitions.h
@@ -5,6 +5,7 @@
 #define ALLOCATED_MAC_ADDRESSES	  "allocated-mac-addresses"
 #define DEFAULT_ALLOCATED_MACS 8
 #define PROP_CURRENT_BANK "current-bank"
+#define PROP_BOOT_TRIES_LEFT "boot_tries_left"
 
 #define ENV_NFS_SERVERIP "serverip"
 #define ENV_NFS_ROOTPATH "rootpath"

--- a/cmd/siklu/siklu_nand_boot.c
+++ b/cmd/siklu/siklu_nand_boot.c
@@ -82,6 +82,7 @@ static int do_nand_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 	int ret;
 
 	bank = bank_management_get_current_bank();
+	bank = bank_management_switch_current_bank(bank);
 
 	printk("Loading images from bank %s...\n", bank->bank_label);
 	ret = init_and_mount_ubifs_bank(bank);

--- a/cmd/siklu/siklu_nand_boot.c
+++ b/cmd/siklu/siklu_nand_boot.c
@@ -81,8 +81,8 @@ static int do_nand_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 	struct software_bank_t *bank;
 	int ret;
 
-	bank = bank_management_get_current_bank();
-	bank = bank_management_handle_auto_switch(bank);
+	bool do_failover = 0 == bank_management_get_boot_tries_left() ? true : false;
+	bank = bank_management_get_current_bank(do_failover);
 
 	printk("Loading images from bank %s...\n", bank->bank_label);
 	ret = init_and_mount_ubifs_bank(bank);

--- a/cmd/siklu/siklu_nand_boot.c
+++ b/cmd/siklu/siklu_nand_boot.c
@@ -82,7 +82,7 @@ static int do_nand_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 	int ret;
 
 	bank = bank_management_get_current_bank();
-	bank = bank_management_switch_current_bank(bank);
+	bank = bank_management_handle_auto_switch(bank);
 
 	printk("Loading images from bank %s...\n", bank->bank_label);
 	ret = init_and_mount_ubifs_bank(bank);

--- a/cmd/siklu/siklu_nand_boot.c
+++ b/cmd/siklu/siklu_nand_boot.c
@@ -81,8 +81,7 @@ static int do_nand_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 	struct software_bank_t *bank;
 	int ret;
 
-	bool do_failover = 0 == bank_management_get_boot_tries_left() ? true : false;
-	bank = bank_management_get_current_bank(do_failover);
+	bank = bank_management_get_current_bank((0 == bank_management_get_boot_tries_left()));
 
 	printk("Loading images from bank %s...\n", bank->bank_label);
 	ret = init_and_mount_ubifs_bank(bank);


### PR DESCRIPTION
This PR adds support for boot counter to support failover switch to another software bank. It uses device_mgmt and works in following way:
* Default value for boot_tries_left > 0 is set by supporting software.
* When boot_tries_left = 0 -- switch bank.
* When boot_tries_left < 0 -- ignore it (no supporting software has booted  after switch).

See https://github.com/siklu/devices/pull/774 for more description
