### PR TITLE
DEV-4969: switch bank when no more boot tries left

### DIFF
--- a/common/siklu/bank_management.c
+++ b/common/siklu/bank_management.c
@@ -28,7 +28,7 @@ create_bank_management_info_for_bank(const struct software_bank_t *bank) {
 	siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
 }
 
-struct software_bank_t* bank_management_get_current_bank(void) {
+struct software_bank_t* bank_management_get_current_bank(bool do_failover) {
 	u_char *fdt = NULL;
 	struct software_bank_t *bank;
 	const char *config_bank_name;
@@ -47,11 +47,15 @@ struct software_bank_t* bank_management_get_current_bank(void) {
 	}
 	
 	if (strcmp(config_bank_name, first_bank.bank_label) == 0) {
-		bank = &first_bank;
+		bank = do_failover ? &second_bank : &first_bank;
 	} else if (strcmp(config_bank_name, second_bank.bank_label) == 0) {
-		bank = &second_bank;
+		bank = do_failover ? &first_bank : &second_bank;
 	} else {
 		goto fail_free;
+	}
+	if (do_failover) {
+		siklu_fdt_setprop_string(fdt, "/", PROP_CURRENT_BANK, bank->bank_label);
+		siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
 	}
 	
 	free(fdt);
@@ -69,4 +73,41 @@ fail:
 	create_bank_management_info_for_bank(bank);
 	
 	return bank;
+}
+
+int8_t bank_management_get_boot_tries_left() {
+	u_char *fdt = NULL;
+	int8_t boot_tries_left = -1; // negative is disabled
+	const char *config_boot_tries_left;
+	char boot_tries_left_str[5]; // "-123\0"
+
+	fdt = siklu_read_fdt_from_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART);
+	if (! fdt) {
+		printk(KERN_ERR "Could not read bank management info from \"%s\"\n",
+			   CONFIG_SIKLU_BANK_MGMT_MTD_PART);
+		return -1;
+	}
+
+	config_boot_tries_left = siklu_fdt_getprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, NULL);
+	if (IS_ERR(config_boot_tries_left)) {
+		printf("SIKLU_BOOT: Could not read boot_tries_left\n");
+		goto fail_free;
+	}
+
+	printf("SIKLU BOOT: boot_tries_left = %s\n", config_boot_tries_left);
+	boot_tries_left = simple_strtol(config_boot_tries_left, NULL, 10);
+	if (boot_tries_left < 0) {
+		// do nothing
+		goto fail_free;
+	}
+
+	// decrement boot_tries_left for next boot
+	if (0 < snprintf(boot_tries_left_str, sizeof(boot_tries_left_str), "%d", boot_tries_left - 1)) {
+		siklu_fdt_setprop_string(fdt, "/", PROP_BOOT_TRIES_LEFT, boot_tries_left_str);
+		siklu_write_fdt_to_mtd_part(CONFIG_SIKLU_BANK_MGMT_MTD_PART, fdt);
+	}
+
+fail_free:
+	free(fdt);
+	return boot_tries_left;
 }

--- a/common/siklu/bank_management.h
+++ b/common/siklu/bank_management.h
@@ -1,14 +1,23 @@
 #ifndef __SIKLU_BANK_MANAGEMENT_H__
 #define __SIKLU_BANK_MANAGEMENT_H__
 
+#include <linux/types.h>
+
 struct software_bank_t {
 	const char* bank_label;
 };
 
 /**
- * Get the current software bank.
+ * Get the current software bank, update current bank if failover happened
+ * @param do_failover  do a bank switch and save changes
  * @return a pointer to a valid software_bank_t.
  */
-struct software_bank_t* bank_management_get_current_bank(void);
+struct software_bank_t* bank_management_get_current_bank(bool do_failover);
+
+/**
+ * Get current boot_tries_left, decrease value for next boot
+ * @return count of boot tries left or -1 on fail
+ */
+int8_t bank_management_get_boot_tries_left();
 
 #endif

--- a/common/siklu/definitions.h
+++ b/common/siklu/definitions.h
@@ -5,6 +5,7 @@
 #define ALLOCATED_MAC_ADDRESSES	  "allocated-mac-addresses"
 #define DEFAULT_ALLOCATED_MACS 8
 #define PROP_CURRENT_BANK "current-bank"
+#define PROP_BOOT_TRIES_LEFT "boot_tries_left"
 
 #define ENV_NFS_SERVERIP "serverip"
 #define ENV_NFS_ROOTPATH "rootpath"

--- a/common/siklu/siklu_nand_boot.c
+++ b/common/siklu/siklu_nand_boot.c
@@ -85,7 +85,7 @@ static int do_nand_boot(cmd_tbl_t *cmdtp, int flag, int argc,
 	struct software_bank_t *bank;
 	int ret;
 
-	bank = bank_management_get_current_bank();
+	bank = bank_management_get_current_bank((0 == bank_management_get_boot_tries_left()));
 
 	printk("Loading images from bank %s...\n", bank->bank_label);
 	ret = init_and_mount_ubifs_bank(bank);


### PR DESCRIPTION
This PR adds support for boot counter to support failover switch to another software bank. It uses device_mgmt and works in following way:
* Default value for boot_tries_left > 0 is set by supporting software.
* When boot_tries_left = 0 -- switch bank.
* When boot_tries_left < 0 -- ignore it (no supporting software has booted  after switch).

See https://github.com/siklu/devices/pull/774 for more description